### PR TITLE
feat: admin mode with login and teacher-only registration endpoints

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -5,7 +5,12 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends, status
+from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
+from jose import JWTError, jwt
+from passlib.hash import sha256_crypt
+import json
+from typing import Optional
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
@@ -18,6 +23,53 @@ app = FastAPI(title="Mergington High School API",
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+# Auth config
+SECRET_KEY = "supersecretkey123"  # 生产环境请更换
+ALGORITHM = "HS256"
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/login")
+
+# Load teacher users
+with open(os.path.join(current_dir, "config", "users.json")) as f:
+    users_data = json.load(f)
+TEACHERS = {u["username"]: u for u in users_data["teachers"]}
+
+def authenticate_user(username: str, password: str) -> Optional[dict]:
+    user = TEACHERS.get(username)
+    if not user:
+        return None
+    # 密码为 sha256 哈希
+    if user["password"] != sha256_crypt.hash(password) and user["password"] != password:
+        return None
+    return user
+
+def create_access_token(data: dict):
+    return jwt.encode(data, SECRET_KEY, algorithm=ALGORITHM)
+
+def get_current_user(token: str = Depends(oauth2_scheme)):
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        username: str = payload.get("sub")
+        if username is None or username not in TEACHERS:
+            raise credentials_exception
+        return TEACHERS[username]
+    except JWTError:
+        raise credentials_exception
+
+
+# 登录接口
+@app.post("/login")
+def login(form_data: OAuth2PasswordRequestForm = Depends()):
+    user = authenticate_user(form_data.username, form_data.password)
+    if not user:
+        raise HTTPException(status_code=400, detail="Incorrect username or password")
+    access_token = create_access_token({"sub": user["username"]})
+    return {"access_token": access_token, "token_type": "bearer"}
 
 # In-memory activity database
 activities = {
@@ -88,45 +140,28 @@ def get_activities():
     return activities
 
 
+
+# 只有教师可注册/注销
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
-    """Sign up a student for an activity"""
-    # Validate activity exists
+def signup_for_activity(activity_name: str, email: str, user: dict = Depends(get_current_user)):
+    """Sign up a student for an activity (admin only)"""
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
-
-    # Get the specific activity
     activity = activities[activity_name]
-
-    # Validate student is not already signed up
     if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
-        )
-
-    # Add student
+        raise HTTPException(status_code=400, detail="Student is already signed up")
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
 
 
+
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
-    """Unregister a student from an activity"""
-    # Validate activity exists
+def unregister_from_activity(activity_name: str, email: str, user: dict = Depends(get_current_user)):
+    """Unregister a student from an activity (admin only)"""
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
-
-    # Get the specific activity
     activity = activities[activity_name]
-
-    # Validate student is signed up
     if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
-        )
-
-    # Remove student
+        raise HTTPException(status_code=400, detail="Student is not signed up for this activity")
     activity["participants"].remove(email)
     return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/config/users.json
+++ b/src/config/users.json
@@ -1,0 +1,14 @@
+{
+    "teachers": [
+        {
+            "username": "smith",
+            "password": "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
+            "display_name": "Mr. Smith"
+        },
+        {
+            "username": "johnson",
+            "password": "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
+            "display_name": "Mrs. Johnson"
+        }
+    ]
+}


### PR DESCRIPTION
实现了 Admin Mode：
- 新增 /login 登录接口，教师账号密码存储于 config/users.json
- 注册/注销活动接口仅限教师（需 Bearer Token）
- 采用 JWT 认证，提升安全性
- 便于后续扩展和权限管理

请审阅。